### PR TITLE
Auction updates

### DIFF
--- a/packages/suins/Move.lock
+++ b/packages/suins/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "95655F3ADDD0B190546C73B5AE084B3C5B55EF28AC213FBE7F61E9BEAFD800DD"
+manifest_digest = "4DFC1BD18B428E6CB2C80C4A70B749DDBE16E3D85D0665F21DF640885E625CDC"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.47.0"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/packages/suins/Move.toml
+++ b/packages/suins/Move.toml
@@ -1,7 +1,6 @@
 [package]
 name = "suins"
 edition = "2024.beta"
-version = "0.0.1"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }

--- a/packages/suins/README.md
+++ b/packages/suins/README.md
@@ -17,6 +17,8 @@ Developers can integrate the core package into their Move-based projects by addi
 
 admin: Provides reserved functions for managing domain registrations and configurations via the authorized AdminCap. Intended to be used by SuiNS administrators or deployers.
 
+auction: 1st party Auction module contain logic for listing SuiNS domains, bidding and placing offers.
+
 constants: Centralized module defining system-wide constants (e.g. domain length bounds, TLDs, grace periods) and helper getters.
 
 controller: Exposes user-facing functionality such as reverse lookup setup, metadata editing, and burning expired records. Requires app-level authorization (ControllerV2).

--- a/packages/suins/sources/auction.move
+++ b/packages/suins/sources/auction.move
@@ -335,8 +335,8 @@ module suins::auction {
         assert!(bid_amount >= auction.min_bid && bid_amount > highest_bid_value, EBidTooLow);
 
         // If bid in last minutes, extend auction by minutes
-        if (auction.end_time - now <= BID_EXTEND_TIME) {
-            auction.end_time = auction.end_time + BID_EXTEND_TIME;
+        if (auction.end_time - now < BID_EXTEND_TIME) {
+            auction.end_time = now + BID_EXTEND_TIME;
         };
 
         if (highest_bid_value > 0) {

--- a/packages/suins/sources/auction.move
+++ b/packages/suins/sources/auction.move
@@ -700,12 +700,12 @@ module suins::auction {
     }
 
     #[test_only]
-    public fun get_auction_table<T>(auction_table: &AuctionTable): &ObjectTable<vector<u8>, Auction<T>> {
+    public fun get_auction_table(auction_table: &AuctionTable): &ObjectBag {
         &auction_table.bag
     }
 
     #[test_only]
-    public fun get_auction<T>(auction_table: &ObjectTable<vector<u8>, Auction<T>>, domain_name: vector<u8>): &Auction<T> {
+    public fun get_auction<T>(auction_table: &ObjectBag, domain_name: vector<u8>): &Auction<T> {
         auction_table.borrow(domain_name)
     }
 

--- a/packages/suins/tests/auction_tests.move
+++ b/packages/suins/tests/auction_tests.move
@@ -216,7 +216,8 @@ fun auction_scenario_sui_test() {
         let auction = auction::get_auction<SUI>(table, FIRST_DOMAIN_NAME);
         assert!(auction::get_owner(auction) == DOMAIN_OWNER, 0);
         assert!(auction::get_start_time(auction) == START_TIME, 0);
-        assert!(auction::get_end_time(auction) == END_TIME + 300, 0); // auction extended by 5 minutes
+        std::debug::print(&auction::get_end_time(auction));
+        assert!(auction::get_end_time(auction) == 410, 0); // auction extended by 5 minutes from now
         assert!(auction::get_min_bid(auction) == SUI_MIN_BID * mist_per_sui(), 0);
         assert!(auction::get_highest_bidder(auction) == FIRST_ADDRESS, 0);
         assert!(auction::get_highest_bid_balance(auction).value() == SUI_FIRST_BID * mist_per_sui(), 0);
@@ -237,7 +238,7 @@ fun auction_scenario_sui_test() {
         let auction = auction::get_auction<SUI>(table, FIRST_DOMAIN_NAME);
         assert!(auction::get_owner(auction) == DOMAIN_OWNER, 0);
         assert!(auction::get_start_time(auction) == START_TIME, 0);
-        assert!(auction::get_end_time(auction) == END_TIME + 300, 0);
+        assert!(auction::get_end_time(auction) == 410, 0);
         assert!(auction::get_min_bid(auction) == SUI_MIN_BID * mist_per_sui(), 0);
         assert!(auction::get_highest_bidder(auction) == SECOND_ADDRESS, 0);
         assert!(auction::get_highest_bid_balance(auction).value() == SUI_SECOND_BID * mist_per_sui(), 0);

--- a/packages/suins/tests/auction_tests.move
+++ b/packages/suins/tests/auction_tests.move
@@ -155,7 +155,7 @@ fun place_bid(
         let payment = coin::mint_for_testing<SUI>(amount * mist_per_sui(), ctx);
         
         // Place the bid
-        auction::place_bid(
+        auction::place_bid<SUI>(
             &mut auction_table,
             domain_name,
             payment,

--- a/packages/suins/tests/auction_tests.move
+++ b/packages/suins/tests/auction_tests.move
@@ -216,7 +216,7 @@ fun auction_scenario_test() {
     // Increment the clock to auction active
     clock.increment_for_testing(TICK_INCREMENT);
 
-    // First address places a bid
+    // First address places a bid, auction time is extended
     place_bid(scenario, FIRST_ADDRESS, FIRST_DOMAIN_NAME, SUI_FIRST_BID, &clock);
 
     // Tx to check auction state
@@ -229,7 +229,7 @@ fun auction_scenario_test() {
         let auction = auction::get_auction(table, FIRST_DOMAIN_NAME);
         assert!(auction::get_owner(auction) == DOMAIN_OWNER, 0);
         assert!(auction::get_start_time(auction) == START_TIME, 0);
-        assert!(auction::get_end_time(auction) == END_TIME, 0);
+        assert!(auction::get_end_time(auction) == END_TIME + 300, 0); // auction extended by 5 minutes
         assert!(auction::get_min_bid(auction) == SUI_MIN_BID * mist_per_sui(), 0);
         assert!(auction::get_highest_bidder(auction) == FIRST_ADDRESS, 0);
         assert!(auction::get_highest_bid_balance(auction).value() == SUI_FIRST_BID * mist_per_sui(), 0);
@@ -237,7 +237,7 @@ fun auction_scenario_test() {
         test_scenario::return_shared(auction_table);
     };
 
-    // Second address places a bid
+    // Second address places a bid, auction time is not extended since clock was not incremented
     place_bid(scenario, SECOND_ADDRESS, FIRST_DOMAIN_NAME, SUI_SECOND_BID, &clock);
 
     // Tx to check auction and accounts state
@@ -250,7 +250,7 @@ fun auction_scenario_test() {
         let auction = auction::get_auction(table, FIRST_DOMAIN_NAME);
         assert!(auction::get_owner(auction) == DOMAIN_OWNER, 0);
         assert!(auction::get_start_time(auction) == START_TIME, 0);
-        assert!(auction::get_end_time(auction) == END_TIME, 0);
+        assert!(auction::get_end_time(auction) == END_TIME + 300, 0);
         assert!(auction::get_min_bid(auction) == SUI_MIN_BID * mist_per_sui(), 0);
         assert!(auction::get_highest_bidder(auction) == SECOND_ADDRESS, 0);
         assert!(auction::get_highest_bid_balance(auction).value() == SUI_SECOND_BID * mist_per_sui(), 0);
@@ -263,7 +263,7 @@ fun auction_scenario_test() {
     };
 
     // Increment the clock to over end auction time
-    clock.increment_for_testing(AUCTION_ACTIVE_TIME * MS);
+    clock.increment_for_testing((AUCTION_ACTIVE_TIME + 300) * MS);
 
     // Finalize the auction
     finalize_auction(scenario, FIRST_DOMAIN_NAME, &clock);

--- a/packages/suins/tests/test_utils/register.move
+++ b/packages/suins/tests/test_utils/register.move
@@ -51,6 +51,9 @@ public fun register<T>(
 
     let label = domain.sld();
     let price = config.calculate_base_price(label.length()) * (no_years as u64);
+
+    std::debug::print(&price);
+
     assert!(payment.value() == price, EIncorrectAmount);
 
     suins.app_add_custom_balance<_, T>(Register {}, payment.into_balance());


### PR DESCRIPTION
Delink SuiNS name and link to new owner after being sold 

5-minute extension rule: If a bid is made on an auction 5 minutes before the end time, the new end time is updated and incremented by 5 minutes.

Extendable to add new payment tokens